### PR TITLE
Move security requirements to a dedicated attribute

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -31,7 +31,32 @@ class UserController extends Controller
      *
      * Creates new user or returns already existing user by email.
      */
-     #[OpenApi\Operation(security: 'BearerTokenSecurityScheme')]
+     #[OpenApi\Operation()]
+     #[OpenApi\SecurityRequirement('BearerTokenSecurityScheme')]
+    public function store(Request $request)
+    {
+        //
+    }
+}
+```
+
+### Specifying OAuth scopes
+
+```php
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+
+#[OpenApi\PathItem]
+class UserController extends Controller
+{
+    /**
+     * Create new user.
+     *
+     * Creates new user or returns already existing user by email.
+     */
+     #[OpenApi\Operation()]
+     #[OpenApi\SecurityRequirement('OAuth2SecurityScheme', ['user_create', 'user_admin'])] // AND
+     // OR
+     #[OpenApi\SecurityRequirement('OAuth2SecurityScheme', ['superadmin'])]
     public function store(Request $request)
     {
         //

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,8 +31,8 @@ class UserController extends Controller
      *
      * Creates new user or returns already existing user by email.
      */
-     #[OpenApi\Operation()]
-     #[OpenApi\SecurityRequirement('BearerTokenSecurityScheme')]
+    #[OpenApi\Operation()]
+    #[OpenApi\SecurityRequirement('BearerTokenSecurityScheme')]
     public function store(Request $request)
     {
         //
@@ -53,10 +53,10 @@ class UserController extends Controller
      *
      * Creates new user or returns already existing user by email.
      */
-     #[OpenApi\Operation()]
-     #[OpenApi\SecurityRequirement('OAuth2SecurityScheme', ['user_create', 'user_admin'])] // AND
-     // OR
-     #[OpenApi\SecurityRequirement('OAuth2SecurityScheme', ['superadmin'])]
+    #[OpenApi\Operation()]
+    #[OpenApi\SecurityRequirement('OAuth2SecurityScheme', ['user_create', 'user_admin'])] // AND
+    // OR
+    #[OpenApi\SecurityRequirement('OAuth2SecurityScheme', ['superadmin'])]
     public function store(Request $request)
     {
         //

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -14,8 +14,6 @@ class Operation
     /** @var array<string> */
     public array $tags;
 
-    public ?string $security;
-
     public ?string $method;
 
     public ?array $servers;
@@ -23,33 +21,15 @@ class Operation
     /**
      * @param  string|null  $id
      * @param  array  $tags
-     * @param  \Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory|string|null  $security
      * @param  string|null  $method
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null)
+    public function __construct(string $id = null, array $tags = [], string $method = null, array $servers = null)
     {
         $this->id = $id;
         $this->tags = $tags;
         $this->method = $method;
         $this->servers = $servers;
-
-        if ($security === '') {
-            //user wants to turn off security on this operation
-            $this->security = $security;
-
-            return;
-        }
-
-        if ($security) {
-            $this->security = class_exists($security) ? $security : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$security;
-
-            if (! is_a($this->security, SecuritySchemeFactory::class, true)) {
-                throw new InvalidArgumentException(
-                    sprintf('Security class is either not declared or is not an instance of %s', SecuritySchemeFactory::class)
-                );
-            }
-        }
     }
 }

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -14,6 +14,8 @@ class Operation
     /** @var array<string> */
     public array $tags;
 
+    public ?string $security;
+
     public ?string $method;
 
     public ?array $servers;
@@ -21,15 +23,37 @@ class Operation
     /**
      * @param  string|null  $id
      * @param  array  $tags
+     * @param  \Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory|string|null  $security Deprecated
      * @param  string|null  $method
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(string $id = null, array $tags = [], string $method = null, array $servers = null)
+    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null)
     {
         $this->id = $id;
         $this->tags = $tags;
         $this->method = $method;
         $this->servers = $servers;
+
+        if ($security !== null) {
+            @trigger_error('Operation()\'s \'security\' argument is deprecated. Use the SecurityRequirement() attribute instead.', E_USER_DEPRECATED);
+        }
+
+        if ($security === '') {
+            //user wants to turn off security on this operation
+            $this->security = $security;
+
+            return;
+        }
+
+        if ($security) {
+            $this->security = class_exists($security) ? $security : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$security;
+
+            if (! is_a($this->security, SecuritySchemeFactory::class, true)) {
+                throw new InvalidArgumentException(
+                    sprintf('Security class is either not declared or is not an instance of %s', SecuritySchemeFactory::class)
+                );
+            }
+        }
     }
 }

--- a/src/Attributes/SecurityRequirement.php
+++ b/src/Attributes/SecurityRequirement.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Vyuldashev\LaravelOpenApi\Attributes;
+
+use Attribute;
+use InvalidArgumentException;
+use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class SecurityRequirement
+{
+    public ?string $scheme;
+
+    /** @var array<string> */
+    public ?array $scopes;
+
+    /**
+     * @param  string|null  $scheme
+     * @param  array  $scopes
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(string|null $scheme, array $scopes = [])
+    {
+        if ($scheme) {
+            $factory = class_exists($scheme) ? $scheme : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$scheme;
+
+            if (! is_a($factory, SecuritySchemeFactory::class, true)) {
+                throw new InvalidArgumentException(
+                    sprintf('Security class is either not declared or is not an instance of %s', SecuritySchemeFactory::class)
+                );
+            }
+        }
+
+        $this->scheme = $scheme;
+        $this->scopes = $scopes;
+    }
+}

--- a/src/Builders/Paths/Operation/SecurityBuilder.php
+++ b/src/Builders/Paths/Operation/SecurityBuilder.php
@@ -3,7 +3,7 @@
 namespace Vyuldashev\LaravelOpenApi\Builders\Paths\Operation;
 
 use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
-use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
+use Vyuldashev\LaravelOpenApi\Attributes\SecurityRequirement as SecurityRequirementAttribute;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
 
 class SecurityBuilder
@@ -11,17 +11,21 @@ class SecurityBuilder
     public function build(RouteInformation $route): array
     {
         return $route->actionAttributes
-            ->filter(static fn (object $attribute) => $attribute instanceof OperationAttribute)
-            ->filter(static fn (OperationAttribute $attribute) => isset($attribute->security))
-            ->map(static function (OperationAttribute $attribute) {
-                // return a null scheme if the security is set to ''
-                if ($attribute->security === '') {
+            ->filter(static fn (object $attribute) => $attribute instanceof SecurityRequirementAttribute)
+            ->map(static function (SecurityRequirementAttribute $attribute) {
+                if (!$attribute->scheme) {
                     return SecurityRequirement::create()->securityScheme(null);
                 }
-                $security = app($attribute->security);
-                $scheme = $security->build();
+                $factory = app($attribute->scheme);
+                $scheme = $factory->build();
 
-                return SecurityRequirement::create()->securityScheme($scheme);
+                $requirement = SecurityRequirement::create()->securityScheme($scheme);
+
+                if ($attribute->scopes) {
+                    $requirement = $requirement->scopes(...$attribute->scopes);
+                }
+
+                return $requirement;
             })
             ->values()
             ->toArray();

--- a/src/Builders/Paths/Operation/SecurityBuilder.php
+++ b/src/Builders/Paths/Operation/SecurityBuilder.php
@@ -3,6 +3,7 @@
 namespace Vyuldashev\LaravelOpenApi\Builders\Paths\Operation;
 
 use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
+use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
 use Vyuldashev\LaravelOpenApi\Attributes\SecurityRequirement as SecurityRequirementAttribute;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
 
@@ -11,21 +12,33 @@ class SecurityBuilder
     public function build(RouteInformation $route): array
     {
         return $route->actionAttributes
-            ->filter(static fn (object $attribute) => $attribute instanceof SecurityRequirementAttribute)
-            ->map(static function (SecurityRequirementAttribute $attribute) {
-                if (!$attribute->scheme) {
-                    return SecurityRequirement::create()->securityScheme(null);
+            ->filter(static fn (object $attribute) => $attribute instanceof OperationAttribute || $attribute instanceof SecurityRequirementAttribute)
+            ->filter(static fn (OperationAttribute|SecurityRequirementAttribute $attribute) => $attribute instanceof SecurityRequirementAttribute || isset($attribute->security))
+            ->map(static function (OperationAttribute|SecurityRequirementAttribute $attribute) {
+                if ($attribute instanceof SecurityRequirementAttribute) {
+                    if (!$attribute->scheme) {
+                        return SecurityRequirement::create()->securityScheme(null);
+                    }
+                    $factory = app($attribute->scheme);
+                    $scheme = $factory->build();
+
+                    $requirement = SecurityRequirement::create()->securityScheme($scheme);
+
+                    if ($attribute->scopes) {
+                        $requirement = $requirement->scopes(...$attribute->scopes);
+                    }
+
+                    return $requirement;
+                } else {
+                    // return a null scheme if the security is set to ''
+                    if ($attribute->security === '') {
+                        return SecurityRequirement::create()->securityScheme(null);
+                    }
+                    $security = app($attribute->security);
+                    $scheme = $security->build();
+
+                    return SecurityRequirement::create()->securityScheme($scheme);
                 }
-                $factory = app($attribute->scheme);
-                $scheme = $factory->build();
-
-                $requirement = SecurityRequirement::create()->securityScheme($scheme);
-
-                if ($attribute->scopes) {
-                    $requirement = $requirement->scopes(...$attribute->scopes);
-                }
-
-                return $requirement;
             })
             ->values()
             ->toArray();

--- a/tests/Builders/SecurityBuilderTest.php
+++ b/tests/Builders/SecurityBuilderTest.php
@@ -9,6 +9,7 @@ use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityScheme;
 use GoldSpecDigital\ObjectOrientedOAS\OpenApi;
 use phpDocumentor\Reflection\DocBlock;
+use Vyuldashev\LaravelOpenApi\Attributes\Operation as AttributesOperation;
 use Vyuldashev\LaravelOpenApi\Attributes\SecurityRequirement as AttributesSecurityRequirement;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\OperationsBuilder;
@@ -161,6 +162,7 @@ class SecurityBuilderTest extends TestCase
         $routeInfo->name = 'test route';
         $routeInfo->actionDocBlock = new DocBlock('Test');
         $routeInfo->actionAttributes = collect([
+            new AttributesOperation(),
             new AttributesSecurityRequirement(null),
         ]);
 

--- a/tests/Builders/SecurityBuilderTest.php
+++ b/tests/Builders/SecurityBuilderTest.php
@@ -9,7 +9,7 @@ use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityScheme;
 use GoldSpecDigital\ObjectOrientedOAS\OpenApi;
 use phpDocumentor\Reflection\DocBlock;
-use Vyuldashev\LaravelOpenApi\Attributes\Operation as AttributesOperation;
+use Vyuldashev\LaravelOpenApi\Attributes\SecurityRequirement as AttributesSecurityRequirement;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\OperationsBuilder;
 use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
@@ -88,7 +88,7 @@ class SecurityBuilderTest extends TestCase
         $routeInfo->action = 'get';
         $routeInfo->name = 'test route';
         $routeInfo->actionAttributes = collect([
-            new AttributesOperation(security: JwtSecurityScheme::class),
+            new AttributesSecurityRequirement(JwtSecurityScheme::class),
         ]);
         $routeInfo->uri = '/example';
 
@@ -161,12 +161,7 @@ class SecurityBuilderTest extends TestCase
         $routeInfo->name = 'test route';
         $routeInfo->actionDocBlock = new DocBlock('Test');
         $routeInfo->actionAttributes = collect([
-            /**
-             * we can set secuity to null to turn it off, as
-             * that's the default value. So '' is next best
-             * option?
-             */
-            new AttributesOperation(security: ''),
+            new AttributesSecurityRequirement(null),
         ]);
 
         /** @var OperationsBuilder */


### PR DESCRIPTION
The current implementation of the `security` property of the `Operation` attribute only allows passing a single `SecuritySchemeFactory`.

This creates the following limitations:
1. You cannot specify multiple schemes
2. You cannot specify scopes
3. You cannot specify combinations of scopes and schemes (ie. [AND & OR conditions](https://swagger.io/docs/specification/v3_0/authentication/#using-multiple-authentication-types))

The current implementation is flawed with regards to the spec as we should be specifying `SecurityRequirement` objects on operations instead, which would allow for full coverage of the spec. Passing `SecurityRequirement` objects directly however, isn't possible as is, so this refactor removed the `security` parameter from the `Operation` attribute and moves it to a dedicated, repeatable attribute, **which is a breaking change**.

### Before
```php
#[Operation(tags: ['MyTag'], security: OAuth2SecurityScheme::class id: 'listSomeStuff')]
// ...

#[Operation(tags: ['MyTag'], security: '', id: 'listPublicStuff')]
// ...
```


### After
```php
#[Operation(tags: ['MyTag'], id: 'listSomeStuff')]
#[SecurityRequirement(OAuth2SecurityScheme::class)]
// ...

#[Operation(tags: ['MyTag'], id: 'listPublicStuff')]
#[SecurityRequirement(null)]
// ...

// New Possibilities
#[Operation(tags: ['MyTag'], id: 'listMoreStuff')]
#[SecurityRequirement(OAuth2SecurityScheme::class, ['scope1'])]
// OR
#[SecurityRequirement(OAuth2SecurityScheme::class, ['scope2'])]
// ...

#[Operation(tags: ['MyTag'], id: 'listEvenMoreStuff')]
#[SecurityRequirement(OAuth2SecurityScheme::class, ['scope1', 'scope2'])] // AND
// ...
```