### PR TITLE
docs: update repo and docs url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@
 
 * deprecation warning with Str::lower() ([#36](https://github.com/Nova-Edge/laravel-openapi/issues/36)) ([a92b4ce](https://github.com/Nova-Edge/laravel-openapi/commit/a92b4ce171daa721c94da23e42bf02c4f5896951))
 
-## [2.0.1](https://github.com/TartanLeGrand/laravel-openapi/compare/v2.0.0...v2.0.1) (2024-12-09)
+## [2.0.1](https://github.com/Nova-Edge/laravel-openapi/compare/v2.0.0...v2.0.1) (2024-12-09)
 
 
 ### Performance Improvements
 
-* **memoization:** add memoization for build referencable schemas ([#30](https://github.com/TartanLeGrand/laravel-openapi/issues/30)) ([7657892](https://github.com/TartanLeGrand/laravel-openapi/commit/765789290c4b43dedf3f7e4f96ef32cbe82a9087))
+* **memoization:** add memoization for build referencable schemas ([#30](https://github.com/Nova-Edge/laravel-openapi/issues/30)) ([7657892](https://github.com/Nova-Edge/laravel-openapi/commit/765789290c4b43dedf3f7e4f96ef32cbe82a9087))
 
-## [2.0.0](https://github.com/TartanLeGrand/laravel-openapi/compare/v1.13.1...v2.0.0) (2024-08-02)
+## [2.0.0](https://github.com/Nova-Edge/laravel-openapi/compare/v1.13.1...v2.0.0) (2024-08-02)
 
 
 ### ⚠ BREAKING CHANGES
@@ -28,29 +28,29 @@
 
 ### Miscellaneous Chores
 
-* remove doctrine ([#17](https://github.com/TartanLeGrand/laravel-openapi/issues/17)) ([ae4695e](https://github.com/TartanLeGrand/laravel-openapi/commit/ae4695e9973fe6b9e70c4c132bdc324c57075635))
+* remove doctrine ([#17](https://github.com/Nova-Edge/laravel-openapi/issues/17)) ([ae4695e](https://github.com/Nova-Edge/laravel-openapi/commit/ae4695e9973fe6b9e70c4c132bdc324c57075635))
 
-## [1.13.1](https://github.com/TartanLeGrand/laravel-openapi/compare/v1.13.0...v1.13.1) (2024-07-13)
+## [1.13.1](https://github.com/Nova-Edge/laravel-openapi/compare/v1.13.0...v1.13.1) (2024-07-13)
 
 
 ### Bug Fixes
 
-* Corrected SchemaFactoryMakeCommand.php to work with Laravel 11 ([#15](https://github.com/TartanLeGrand/laravel-openapi/issues/15)) ([b0f57cf](https://github.com/TartanLeGrand/laravel-openapi/commit/b0f57cf0b56a0edbe686a0202631e9cfc9b8283a))
+* Corrected SchemaFactoryMakeCommand.php to work with Laravel 11 ([#15](https://github.com/Nova-Edge/laravel-openapi/issues/15)) ([b0f57cf](https://github.com/Nova-Edge/laravel-openapi/commit/b0f57cf0b56a0edbe686a0202631e9cfc9b8283a))
 
 
 ### Miscellaneous Chores
 
-* **deps:** update actions/setup-node action to v4 ([#7](https://github.com/TartanLeGrand/laravel-openapi/issues/7)) ([e53fc5e](https://github.com/TartanLeGrand/laravel-openapi/commit/e53fc5e09aadbbc40f63cfa236155e57a23630a6))
-* **deps:** update dependency vuepress to v1.9.10 ([#2](https://github.com/TartanLeGrand/laravel-openapi/issues/2)) ([9d80e06](https://github.com/TartanLeGrand/laravel-openapi/commit/9d80e069c75cb65fe73a5fcd6f994e3c453a15f7))
+* **deps:** update actions/setup-node action to v4 ([#7](https://github.com/Nova-Edge/laravel-openapi/issues/7)) ([e53fc5e](https://github.com/Nova-Edge/laravel-openapi/commit/e53fc5e09aadbbc40f63cfa236155e57a23630a6))
+* **deps:** update dependency vuepress to v1.9.10 ([#2](https://github.com/Nova-Edge/laravel-openapi/issues/2)) ([9d80e06](https://github.com/Nova-Edge/laravel-openapi/commit/9d80e069c75cb65fe73a5fcd6f994e3c453a15f7))
 
-## [1.13.0](https://github.com/TartanLeGrand/laravel-openapi/compare/v1.12.0...v1.13.0) (2024-04-12)
+## [1.13.0](https://github.com/Nova-Edge/laravel-openapi/compare/v1.12.0...v1.13.0) (2024-04-12)
 
 
 ### Features
 
-* **deps:** support laravel 11 ([#6](https://github.com/TartanLeGrand/laravel-openapi/issues/6)) ([278031d](https://github.com/TartanLeGrand/laravel-openapi/commit/278031da0d02bcc6b204ab61390e7e4c91de391d))
+* **deps:** support laravel 11 ([#6](https://github.com/Nova-Edge/laravel-openapi/issues/6)) ([278031d](https://github.com/Nova-Edge/laravel-openapi/commit/278031da0d02bcc6b204ab61390e7e4c91de391d))
 
 
 ### Miscellaneous Chores
 
-* **deps:** update actions/checkout action to v4 ([#3](https://github.com/TartanLeGrand/laravel-openapi/issues/3)) ([c4b4794](https://github.com/TartanLeGrand/laravel-openapi/commit/c4b479401102b88bd6e6ea06ba2610288dbb292d))
+* **deps:** update actions/checkout action to v4 ([#3](https://github.com/Nova-Edge/laravel-openapi/issues/3)) ([c4b4794](https://github.com/Nova-Edge/laravel-openapi/commit/c4b479401102b88bd6e6ea06ba2610288dbb292d))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Documentation
 
-You'll find the documentation on https://tartanlegrand.github.io/laravel-openapi.
+You'll find the documentation on https://nova-edge.github.io/laravel-openapi.
 
 ## License
 
@@ -19,9 +19,9 @@ We invite you to join our community and contribute to the project. Whether you'r
 
 ### How to Contribute
 
-1. **Report a Bug**: Open a [GitHub issue](https://github.com/TartanLeGrand/laravel-openapi/issues) to report bugs or propose improvements.
+1. **Report a Bug**: Open a [GitHub issue](https://github.com/Nova-Edge/laravel-openapi/issues) to report bugs or propose improvements.
 2. **Submit Code**: For development details, see the [CONTRIBUTING](CONTRIBUTING.md) guide. For major changes, including CLI interface changes, please open an issue first to discuss what you would like to change.
-3. **Documentation**: Help us improve the documentation on [our site](https://tartanlegrand.github.io/laravel-openapi).
+3. **Documentation**: Help us improve the documentation on [our site](https://nova-edge.github.io/laravel-openapi).
 
 Thanks to everyone who has contributed, including bug reports, code, feedback, and suggestions!
 
@@ -29,7 +29,7 @@ Thanks to everyone who has contributed, including bug reports, code, feedback, a
 
 A big thank you to all who have contributed to this project. Here are some of our most active contributors:
 
-<a href="https://github.com/tartanlegrand/laravel-openapi/graphs/contributors">
+<a href="https://github.com/Nova-Edge/laravel-openapi/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=tartanlegrand/laravel-openapi" />
 </a>
 
@@ -37,6 +37,6 @@ If you would like to see your name here, start contributing today!
 
 ## Join Us
 
-Connect with other users and contributors on our [discussion forum](https://github.com/TartanLeGrand/laravel-openapi/discussions) and join the conversation around the project.
+Connect with other users and contributors on our [discussion forum](https://github.com/Nova-Edge/laravel-openapi/discussions) and join the conversation around the project.
 
 We ❤️ contributions big or small. Thank you for being part of our community and helping improve this open source project.


### PR DESCRIPTION
Updated the URL of the GitHub Pages documentation that were broken due to the change in GitHub's organization name.

Also updated the old URLs written in the CHANGELOG to link to the new repo.